### PR TITLE
Feature/api key parameter

### DIFF
--- a/fundamentals.py
+++ b/fundamentals.py
@@ -32,6 +32,13 @@ sub_endpoints = {
 for endpoint in endpoints:
     if endpoint in sub_endpoints:
         for sub_endpoint in sub_endpoints[endpoint]:
-            fetch_data_for_endpoint(endpoint=endpoint, sub_endpoint=sub_endpoint)
+            fetch_data_for_endpoint(
+                api_key="your API key",
+                endpoint=endpoint,
+                sub_endpoint=sub_endpoint,
+            )
     else:
-        fetch_data_for_endpoint(endpoint=endpoint)
+        fetch_data_for_endpoint(
+            api_key="your API key",
+            endpoint=endpoint,
+        )

--- a/market.py
+++ b/market.py
@@ -11,5 +11,9 @@ end_date = int(
 
 # Fetch from Finnhub API
 fetch_data_for_endpoint(
-    endpoint="candle", start_date=start_date, end_date=end_date, resolution="D"
+    api_key="Your Finnhub API key here",
+    endpoint="candle",
+    start_date=start_date,
+    end_date=end_date,
+    resolution="D",
 )


### PR DESCRIPTION
- Update `fetch_finnhub` module to use `api_key` as parameter rather than global variable in script
- Update examples to use new `api_key` param for `fetch_data_for_endpoint()` entry function